### PR TITLE
Add option 'default' to sirius-script-app-demag

### DIFF
--- a/bin/sirius-script-app-demag.py
+++ b/bin/sirius-script-app-demag.py
@@ -15,7 +15,8 @@ from multiprocessing import Process
 _dt = 0.5  # [s]
 parms = {
     # dt, ampl, nrpts_period, nr_periods, tau_period, sin_squared?
-    'TB-Fam:PS-B': [_dt, 250.0, 4*(18+1), 6, 1.5, True],  # 42.6 [A/s]
+    # 'TB-Fam:PS-B': [_dt, 250.0, 4*(18+1), 6, 1.5, True],  # 42.6 [A/s]
+    'TB-Fam:PS-B': [_dt, 300.0, 4*(3+1), 32, 4.0, True],  # 42.6 [A/s]
 
     'TB-01:PS-QD1': [_dt, 10.0, 4*(11+1), 10, 2, False],  # 2.9 [A/s]
     'TB-01:PS-QF1': [_dt, 10.0, 4*(11+1), 10, 2, False],  # 2.9 [A/s]
@@ -262,6 +263,10 @@ def select_psnames(psgroup):
         for ps in allps:
             if ps.startswith('LA-CN'):
                 psnames.append(ps)
+    elif psgroup.lower() == 'default':
+        for ps in allps:
+            if ps.startswith('LA-CN') or ps == 'TB-Fam:PS-B':
+                psnames.append(ps)
     else:
         print('Invalid ps group {}!'.format(psgroup))
     return list(set(psnames))
@@ -358,6 +363,8 @@ def print_help():
     print("       --rampdown           ramp selected power supplies down to zero current")
     print("")
     print("       all                  demag all magnets")
+    print("")
+    print("       default              demag LI magnets and TB dipoles")
     print("")
     print("       tb-dipoles           demag TB dipoles")
     print("")


### PR DESCRIPTION
Add *default* option to demag magnets. The idea is to demag TB dipoles together with LI magnets, moving it from the Cycling window to the script, thus decreasing the duration of the demag process from the cycling window, since demag of TB dipoles is the slowest one in the process...

- Option *default* demag all LI power supplies and TB dipoles together.