### PR TITLE
Modify pcaspy and pyepics versions to be consistent with other systems

### DIFF
--- a/workstation_setup/install_pyepics.sh
+++ b/workstation_setup/install_pyepics.sh
@@ -12,6 +12,6 @@ sudo apt-get install -y swig
 export EPICS_BASE=/opt/epics/base
 export EPICS_HOST_ARCH=linux-x86_64
 
-sudo -HE pip-sirius install pyepics==3.3.3
-sudo -HE pip-sirius install pcaspy==0.7.2
+sudo -HE pip-sirius install pyepics==3.3.1
+sudo -HE pip-sirius install pcaspy==0.7.1
 exit 0


### PR DESCRIPTION
These "downgraded" versions have been used in BBBs and Sirius desktops since the beginning and they seem stable.