### PR TITLE
Separate BO PS iocs into fam and corr.

### DIFF
--- a/bin/Makefile
+++ b/bin/Makefile
@@ -6,7 +6,8 @@ GENERALSCRIPTS = \
 		sirius-script-app-demag.py \
 		sirius-script-app-ps-pvsprint.py \
 		sirius-script-services-ioc-bo-ma.bash \
-		sirius-script-services-ioc-bo-ps.bash \
+		sirius-script-services-ioc-bo-ps-fam.bash \
+		sirius-script-services-ioc-bo-ps-corr.bash \
 		sirius-script-services-ioc-dclinks-ps.bash \
 		sirius-script-services-ioc-fac.bash \
 		sirius-script-services-ioc-li-ps.bash \

--- a/bin/sirius-script-services-ioc-bo-ps-corr.bash
+++ b/bin/sirius-script-services-ioc-bo-ps-corr.bash
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+source /usr/local/bin/sirius-script-utils.bash
+trap _abort SIGINT;
+
+
+function print_help {
+    printf "NAME\n"
+    printf "       sirius-script-services-ioc-bo-ps-corr.bash - Interact with IOC services for Corrector Power Supplies\n"
+    printf "\n"
+    printf "SINOPSIS\n"
+    printf "       sirius-script-services-ioc-bo-ps-corr.bash [--help] CMD...\n"
+    printf "\n"
+    printf "DESCRIPTION\n"
+    printf "       Script used to interact with IOC services for power supplies\n"
+    printf "\n"
+    printf "       --help               print this help\n"
+    printf "\n"
+    printf "       status               return status of services\n"
+    printf "\n"
+    printf "       start                start services\n"
+    printf "\n"
+    printf "       stop                 stop services\n"
+    printf "\n"
+    printf "       restart              stop services\n"
+    printf "\n"
+    printf "AUTHOR\n"
+    printf "       FACS-LNLS.\n"
+}
+
+function run_systemctl {
+  cmd=$1
+  host=$2
+  printf_blue "Runnnig systemctl $cmd for services at $host.\n"
+  printf "\n"
+  for service in ${services_ioc_bo_ps_corr[@]}; do
+    printf_yellow "$service...\n"
+    sudo systemctl $cmd $service
+    printf "\n"
+  done
+}
+
+function run {
+  if [ ! $# -eq 1 ]; then
+    print_help
+    exit
+  elif [[ "$1" == "--help" ]]; then
+    print_help
+    exit
+  fi
+
+  host=$(hostname)
+  if [[ "$host" == "$server_services_ioc_bo_ps_corr" ]]; then
+    run_systemctl $1 $server_services_ioc_bo_ps_corr
+  else
+    get_password sirius $server_services_ioc_bo_ps_corr
+    sshpass -p $user_passwd ssh -t sirius@$server_services_ioc_bo_ps_corr "sudo sirius-script-services-ioc-bo-ps-corr.bash $1"
+  fi
+}
+
+
+run $@

--- a/bin/sirius-script-services-ioc-bo-ps-fam.bash
+++ b/bin/sirius-script-services-ioc-bo-ps-fam.bash
@@ -6,10 +6,10 @@ trap _abort SIGINT;
 
 function print_help {
     printf "NAME\n"
-    printf "       sirius-script-services-ioc-bo-ps.bash - Interact with IOC services for Power Supplies\n"
+    printf "       sirius-script-services-ioc-bo-ps-fam.bash - Interact with IOC services for Family Power Supplies\n"
     printf "\n"
     printf "SINOPSIS\n"
-    printf "       sirius-script-services-ioc-bo-ps.bash [--help] CMD...\n"
+    printf "       sirius-script-services-ioc-bo-ps-fam.bash [--help] CMD...\n"
     printf "\n"
     printf "DESCRIPTION\n"
     printf "       Script used to interact with IOC services for power supplies\n"
@@ -33,7 +33,7 @@ function run_systemctl {
   host=$2
   printf_blue "Runnnig systemctl $cmd for services at $host.\n"
   printf "\n"
-  for service in ${services_ioc_bo_ps[@]}; do
+  for service in ${services_ioc_bo_ps_fam[@]}; do
     printf_yellow "$service...\n"
     sudo systemctl $cmd $service
     printf "\n"
@@ -50,11 +50,11 @@ function run {
   fi
 
   host=$(hostname)
-  if [[ "$host" == "$server_services_ioc_bo_ps" ]]; then
-    run_systemctl $1 $server_services_ioc_bo_ps
+  if [[ "$host" == "$server_services_ioc_bo_ps_fam" ]]; then
+    run_systemctl $1 $server_services_ioc_bo_ps_fam
   else
-    get_password sirius $server_services_ioc_bo_ps
-    sshpass -p $user_passwd ssh -t sirius@$server_services_ioc_bo_ps "sudo sirius-script-services-ioc-bo-ps.bash $1"
+    get_password sirius $server_services_ioc_bo_ps_fam
+    sshpass -p $user_passwd ssh -t sirius@$server_services_ioc_bo_ps_fam "sudo sirius-script-services-ioc-bo-ps-fam.bash $1"
   fi
 }
 

--- a/bin/sirius-script-utils.bash
+++ b/bin/sirius-script-utils.bash
@@ -223,13 +223,16 @@ services_ioc_tb_ps=(
   "sirius-ioc-tb-ps-correctors.service"
   )
 
-services_ioc_bo_ps=(
+services_ioc_bo_ps_fam=(
   "sirius-ioc-bo-ps-dipole-1.service"
   "sirius-ioc-bo-ps-dipole-2.service"
   "sirius-ioc-bo-ps-quadrupole-qf.service"
   "sirius-ioc-bo-ps-quadrupole-qd.service"
   "sirius-ioc-bo-ps-sextupole-sf.service"
   "sirius-ioc-bo-ps-sextupole-sd.service"
+  )
+
+services_ioc_bo_ps_corr=(
   "sirius-ioc-bo-ps-correctors-ia01.service"
   "sirius-ioc-bo-ps-correctors-ia02.service"
   "sirius-ioc-bo-ps-correctors-ia04.service"
@@ -244,6 +247,7 @@ services_ioc_bo_ps=(
   "sirius-ioc-bo-ps-correctors-ia17.service"
   "sirius-ioc-bo-ps-correctors-ia20.service"
   )
+
 
 services_ioc_ts_ps=(
   "sirius-ioc-ts-ps-dipoles.service"
@@ -479,6 +483,7 @@ services_ioc_fac=(
 
 
 
+
 mirror_repos_path=/home/sirius/repos
 
 servweb_hostname=10.0.38.59
@@ -491,13 +496,15 @@ servweb_repodir=/home/con-srv/LA-disk0/misc-brick/repository/control-system-cons
 
 server_services_ioc_fac=lnls454-linux
 
-server_services_ioc_dclinks_ps=lnls560-linux
+server_services_ioc_dclinks_ps=lnlsfac-vm
 
 server_services_ioc_li_ps=lnls560-linux
 
 server_services_ioc_tb_ps=lnls560-linux
 
-server_services_ioc_bo_ps=lnls560-linux
+server_services_ioc_bo_ps_fam=lnls560-linux
+
+server_services_ioc_bo_ps_corr=lnlsfac-vm
 
 server_services_ioc_ts_ps=lnls560-linux
 


### PR DESCRIPTION
- run booster ps and dclink iocs in lnlsfac-vm, instead of lnls560-linux