### PR TITLE
Adapt BPM acquisition script to new version of acquisition class

### DIFF
--- a/bin/sirius-script-si-acquire-bpm-triggered-data.py
+++ b/bin/sirius-script-si-acquire-bpm-triggered-data.py
@@ -84,7 +84,7 @@ if __name__ == "__main__":
         description="BPM triggered acquisition script. By default the script is configured to acquire injection perturbations during top-up.")
     parser.add_argument(
         '-f', '--filename', type=str, default='',
-        help='name of the file to save (Default: acqrate_%Y-%m-%d_%Hh%Mm%Ss)')
+        help='name of the file to save (Default: acqrate_YY-MM-DD_HHhMMmSSs)')
     parser.add_argument(
         '-s', '--signals2acq', type=str, default='XY',
         help='signals to acquire (Default: XY)')

--- a/bin/sirius-script-si-acquire-bpm-triggered-data.py
+++ b/bin/sirius-script-si-acquire-bpm-triggered-data.py
@@ -21,7 +21,7 @@ def configure_acquisition_params(orbacq):
 
     params.nrpoints_before = 1_000
     params.nrpoints_after = 10_000
-    params._acq_repeat = 0
+    params.acq_repeat = False
     params.trigbpm_delay = 0
     params.trigbpm_nrpulses = 1
     params.do_pulse_evg = False

--- a/bin/sirius-script-si-acquire-bpm-triggered-data.py
+++ b/bin/sirius-script-si-acquire-bpm-triggered-data.py
@@ -2,25 +2,26 @@
 """."""
 
 from siriuspy.devices import BunchbyBunch, SOFB, HLFOFB
-from apsuite.commisslib.measure_orbit_stability import \
-        OrbitAcquisition
+from apsuite.commisslib.meas_bpms_signals import AcqBPMsSignals
 from siriuspy.devices import BOPSRampStandbyHandler, BORFRampStandbyHandler
 import sys
+from datetime import datetime
 
 
 def configure_acquisition_params(orbacq):
     """."""
     params = orbacq.params
+    params.signals2acq = 'XY'
 
     # params.orbit_acq_rate = 'FAcq'
     # params.orbit_timeout = 100
 
-    params.orbit_acq_rate = 'TbT'
-    params.orbit_timeout = 60*4  # 3 minutes between top-up injections
+    params.acq_rate = 'TbT'
+    params.timeout = 60*4  # 3 minutes between top-up injections
 
-    params.orbit_nrpoints_before = 1_000
-    params.orbit_nrpoints_after = 10_000
-    params.orbit_acq_repeat = 0
+    params.nrpoints_before = 1_000
+    params.nrpoints_after = 10_000
+    params._acq_repeat = 0
     params.trigbpm_delay = 0
     params.trigbpm_nrpulses = 1
     params.do_pulse_evg = False
@@ -32,17 +33,17 @@ def configure_acquisition_params(orbacq):
 
 def measure(orbacq):
     """."""
-    init_state_orbacq = orbacq.get_initial_state()
+    init_state_orbacq = orbacq.get_timing_state()
     orbacq.prepare_timing()
     print('Waiting for next injection pulse')
     print('Take a look at Injection Control Log to check for next injection')
     orbacq.acquire_data()
-    orbacq.recover_initial_state(init_state_orbacq)
-
+    orbacq.recover_timing_state(init_state_orbacq)
+    return orbacq.data is not None
 
 def initialize():
     """."""
-    orbacq = OrbitAcquisition(isonline=True)
+    orbacq = AcqBPMsSignals(isonline=True)
     configure_acquisition_params(orbacq)
     print('--- orbit acquisition connection ---')
     print(orbacq.wait_for_connection(timeout=100))
@@ -64,16 +65,13 @@ def create_devices():
 def read_feedback_status(devs, orbacq):
     """."""
     sofb, fofb, bbbl, bbbh, bbbv, bopsrmp, borfrmp = devs
-    if orbacq.data is not None:
-        orbacq.data['sofb_loop_state'] = sofb.autocorrsts
-        orbacq.data['fofb_loop_state'] = fofb.loop_state
-        orbacq.data['bbbl_loop_state'] = bbbl.feedback.loop_state
-        orbacq.data['bbbh_loop_state'] = bbbh.feedback.loop_state
-        orbacq.data['bbbv_loop_state'] = bbbv.feedback.loop_state
-        orbacq.data['bo_ps_ramp_state'] = bopsrmp.is_on
-        orbacq.data['bo_rf_ramp_state'] = borfrmp.is_on
-    else:
-        raise Exception('data is None, problem with acquisition!')
+    orbacq.data['sofb_loop_state'] = sofb.autocorrsts
+    orbacq.data['fofb_loop_state'] = fofb.loop_state
+    orbacq.data['bbbl_loop_state'] = bbbl.feedback.loop_state
+    orbacq.data['bbbh_loop_state'] = bbbh.feedback.loop_state
+    orbacq.data['bbbv_loop_state'] = bbbv.feedback.loop_state
+    orbacq.data['bo_ps_ramp_state'] = bopsrmp.is_on
+    orbacq.data['bo_rf_ramp_state'] = borfrmp.is_on
 
 
 if __name__ == "__main__":
@@ -81,8 +79,13 @@ if __name__ == "__main__":
     orbacq = initialize()
     devs = create_devices()
 
-    measure(orbacq)
-    read_feedback_status(devs, orbacq)
+    if measure(orbacq):
+        read_feedback_status(devs, orbacq)
+        now = datetime.now()
+        snow = now.strftime('%Y-%m-%d_%Hh%Mm%Ss')
+        filename = sys.argv[1]
+        orbacq.save_data(snow + '_' + filename, overwrite=False)
+        print(f'\nData saved at {snow:s}')
+    else:
+        print('\nData NOT saved!')
 
-    filename = sys.argv[1]
-    orbacq.save_data(filename, overwrite=False)

--- a/bin/sirius-script-si-acquire-bpm-triggered-data.py
+++ b/bin/sirius-script-si-acquire-bpm-triggered-data.py
@@ -4,7 +4,6 @@
 from siriuspy.devices import BunchbyBunch, SOFB, HLFOFB
 from apsuite.commisslib.meas_bpms_signals import AcqBPMsSignals
 from siriuspy.devices import BOPSRampStandbyHandler, BORFRampStandbyHandler
-import sys
 from datetime import datetime
 
 def configure_acquisition_params(orbacq, parse_args):
@@ -31,12 +30,16 @@ def configure_acquisition_params(orbacq, parse_args):
 
 def measure(orbacq):
     """."""
-    init_state_orbacq = orbacq.get_timing_state()
+    init_state = orbacq.get_timing_state()
     orbacq.prepare_timing()
     print('Waiting for next injection pulse')
     print('Take a look at Injection Control Log to check for next injection')
-    orbacq.acquire_data()
-    orbacq.recover_timing_state(init_state_orbacq)
+    try:
+        orbacq.acquire_data()
+    except Exception as e:
+        print(f"An error occurred during acquisition: {e}")
+    # Restore initial timing state, regardless acquisition status
+    orbacq.recover_timing_state(init_state)
     return orbacq.data is not None
 
 


### PR DESCRIPTION
```
usage: sirius-script-si-acquire-bpm-triggered-data.py [-h] [-f FILENAME] [-s SIGNALS2ACQ] [-r ACQRATE] [-t TIMEOUT] [-b NRPTSBEFORE] [-a NRPTSAFTER] [-e EVENTNAME] [-m EVENTMODE] [-p]

BPM triggered acquisition script. By default the script is configured to acquire injection perturbations during top-up.

optional arguments:
  -h, --help            show this help message and exit
  -f FILENAME, --filename FILENAME
                        name of the file to save (Default: acqrate_YY-MM-DD_HHhMMmSSs)
  -s SIGNALS2ACQ, --signals2acq SIGNALS2ACQ
                        signals to acquire (Default: XY)
  -r ACQRATE, --acqrate ACQRATE
                        acquisition Rate (Default: TbT)
  -t TIMEOUT, --timeout TIMEOUT
                        acquisition timeout [s] (Default: 200 [s])
  -b NRPTSBEFORE, --nrptsbefore NRPTSBEFORE
                        nr points before trigger (Default: 1000)
  -a NRPTSAFTER, --nrptsafter NRPTSAFTER
                        nr points after trigger (Default: 10000)
  -e EVENTNAME, --eventname EVENTNAME
                        timing event name (Default: Linac)
  -m EVENTMODE, --eventmode EVENTMODE
                        timing event mode (Default: Injection)
  -p, --pulseevg        pulse EVG? (Default: False)
  ```