### PR TITLE
Add CAX RIO IOCs IP

### DIFF
--- a/bin/sirius-script-mamba-env-create.bash
+++ b/bin/sirius-script-mamba-env-create.bash
@@ -452,8 +452,8 @@ function defvar ()
 # =====
 defvar "EPICS_BASE" "${CONDA_PREFIX}/epics"
 defvar "EPICS_HOST_ARCH" 'linux-x86_64'
-defvar "EPICS_CA_ADDR_LIST" "10.0.38.59:62000 10.30.14.19"
-defvar "EPICS_PVA_ADDR_LIST" "10.0.38.59:62000 10.30.14.19 "
+defvar "EPICS_CA_ADDR_LIST" "10.0.38.59:62000 10.30.13.22 10.30.14.19"
+defvar "EPICS_PVA_ADDR_LIST" "10.0.38.59:62000 10.30.13.22 10.30.14.19 "
 defvar "SIRIUS_URL_RBAC_AUTH" "https://sirius-rbac-auth.lnls.br"
 defvar "SIRIUS_URL_RBAC" "https://rbac:8445"
 defvar "SIRIUS_URL_NS" "http://naming-service-wildfly:8089"

--- a/bin/sirius-script-mamba-env-create.bash
+++ b/bin/sirius-script-mamba-env-create.bash
@@ -453,7 +453,7 @@ function defvar ()
 defvar "EPICS_BASE" "${CONDA_PREFIX}/epics"
 defvar "EPICS_HOST_ARCH" 'linux-x86_64'
 defvar "EPICS_CA_ADDR_LIST" "10.0.38.59:62000 10.30.13.22 10.30.14.19"
-defvar "EPICS_PVA_ADDR_LIST" "10.0.38.59:62000 10.30.13.22 10.30.14.19 "
+defvar "EPICS_PVA_ADDR_LIST" "10.0.38.59:62000 10.30.13.22 10.30.14.19"
 defvar "SIRIUS_URL_RBAC_AUTH" "https://sirius-rbac-auth.lnls.br"
 defvar "SIRIUS_URL_RBAC" "https://rbac:8445"
 defvar "SIRIUS_URL_NS" "http://naming-service-wildfly:8089"


### PR DESCRIPTION
- so that access to CAX RIO IOCs (mirror temperatures and photocollector IA0 signal) from control rooms desktops is possible.