### PR TITLE
Fix mamba installation.

### DIFF
--- a/bin/sirius-script-mamba-env-create.bash
+++ b/bin/sirius-script-mamba-env-create.bash
@@ -297,22 +297,21 @@ sudo chown -R $USER:mamba ~/.conda
 
 printf_yellow_clear "Adding mamba and conda to path\n"
 source /opt/mamba_files/mamba/etc/profile.d/conda.sh
-source /opt/mamba_files/mamba/etc/profile.d/mamba.sh
+export MAMBA_ROOT_PREFIX='/opt/mamba_files/mamba'
+eval "$(mamba shell hook --shell bash)"
 
 printf_yellow_clear "Adding mamba and conda paths to .bashrc: "
 cd ~/
-if ! grep -q "MAMBA_ADD" .bashrc;
+if ! grep -q "CONDA_ADD" .bashrc;
 then
     cat >> ~/.bashrc <<'EOM'
 # add conda and mamba to path
-MAMBA_ADD=/opt/mamba_files/mamba/etc/profile.d/mamba.sh
-if [ -f "$MAMBA_ADD" ] ; then
-    source "$MAMBA_ADD"
-fi
 CONDA_ADD=/opt/mamba_files/mamba/etc/profile.d/conda.sh
 if [ -f "$CONDA_ADD" ] ; then
     source "$CONDA_ADD"
 fi
+export MAMBA_ROOT_PREFIX='/opt/mamba_files/mamba'
+eval "$(mamba shell hook --shell bash)"
 EOM
     printf_green "done!\n"
 else

--- a/bin/sirius-script-mamba-env-create.bash
+++ b/bin/sirius-script-mamba-env-create.bash
@@ -10,7 +10,7 @@ set -e
 function help
 {
     echo "Usage: sirius-script-mamba-env-create.bash
-    [ -n | --no-clone-repos ] Instead of cloning, find repos in system.
+    [ -c | --clone-repos ] Instead of finding repos in system, clone them inside environment folder.
     [ -d | --develop ] Install sirius packages in develop mode.
     [ --no-sim ] Do not install simulation packages.
     [ --no-ioc ] Do not install IOC related packages.
@@ -33,8 +33,8 @@ function help
     [ -h | --help  ] Print help and exit."
 }
 
-SHORT="ndb:e:h"
-LONG+="no-clone-repos,develop,no-sim,no-ioc,no-ima,no-colleff,root-lnls-fac:,"
+SHORT="cdb:e:h"
+LONG+="clone-repos,develop,no-sim,no-ioc,no-ima,no-colleff,root-lnls-fac:,"
 LONG+="root-lnls-sirius:,root-lnls-ima:,branches:,env-name:,help"
 OPTS=$(getopt -a -n sirius-script-mamba-env-create.bash \
     --options $SHORT --longoptions $LONG -- "$@")
@@ -48,7 +48,7 @@ fi
 
 eval set -- "$OPTS"
 
-CLONE="yes"
+CLONE="no"
 DEVELOP="no"
 INST_SIM="yes"
 INST_IOC="yes"
@@ -62,8 +62,8 @@ ENV_NAME="sirius"
 # now enjoy the options in order and nicely split until we see --
 while true; do
     case "$1" in
-        -n|--no-clone-repos)
-            CLONE="no"
+        -c|--clone-repos)
+            CLONE="yes"
             shift
             ;;
         -d|--develop)

--- a/bin/sirius-script-mamba-env-create.bash
+++ b/bin/sirius-script-mamba-env-create.bash
@@ -359,7 +359,7 @@ printf_yellow_clear "- Install EPICS Base:\n"
 $COMM -c conda-forge/label/cf202003 epics-base=3.15.6
 
 printf_yellow_clear "- And some other EPICS packages:\n"
-$COMM pyepics=3.5.0 pcaspy==0.7.3 pydm=1.10.3 timechart=1.2.3
+$COMM pyepics=3.5.7 pcaspy==0.7.3 pydm=1.10.3 timechart=1.2.3
 # remove the activate and deactivate files created by pyepics and pydm:
 cd $CONDA_PREFIX/etc/conda/activate.d
 if [ -f "pydm.bat" ]

--- a/bin/sirius-script-mamba-env-create.bash
+++ b/bin/sirius-script-mamba-env-create.bash
@@ -229,7 +229,6 @@ clone_or_find()
         printf_yellow_clear "Checking out to branch $BRAN.\n"
         git checkout $BRAN
     fi
-    # wont be nice to fetch and pull the latest updates of the branch? Instead of only "checkouting" it.
 }
 
 ##############################################################################

--- a/bin/sirius-script-mamba-env-create.bash
+++ b/bin/sirius-script-mamba-env-create.bash
@@ -441,9 +441,12 @@ then
     clone_or_find insertion-devices lnls-ima && make $TARGET
 fi
 
+printf_yellow_clear "Deactivate conda enviroment\n"
+mamba deactivate
+
 printf_yellow "Add enviroment variables to conda environment\n"
 
-#### Cria arquivo para configurar ativação do ambiente
+#### Create file to configure environment activation
 cat > $CONDA_PREFIX/etc/conda/activate.d/sirius_env.sh <<'EOM'
 # Define function to set variable and save previous state
 function defvar ()
@@ -541,9 +544,6 @@ undefvar "PYQTDESIGNERPATH"
 unalias g-conda
 unalias g-conda-repos
 EOM
-
-printf_yellow_clear "Deactivate conda enviroment\n"
-mamba deactivate
 
 ##############################################################################
 printf_yellow "Fix permissions of some files\n"

--- a/bin/sirius-script-mamba-env-create.bash
+++ b/bin/sirius-script-mamba-env-create.bash
@@ -281,9 +281,10 @@ printf_yellow_clear "Install mamba in path /opt/mamba_files/mamba: "
 cd /opt/mamba_files
 if ! [ -d mamba ]
 then
-    wget https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-x86_64.sh
-    sh Mambaforge-Linux-x86_64.sh -b -p /opt/mamba_files/mamba
-    rm Mambaforge-Linux-x86_64.sh
+    fname="Miniforge3-Linux-x86_64.sh"
+    wget https://github.com/conda-forge/miniforge/releases/latest/download/$fname
+    sh $fname -b -p /opt/mamba_files/mamba
+    rm $fname
     printf_green "done!\n"
 else
     printf_blue "there already is a mamba installation. Skipping...\n"

--- a/bin/sirius-script-mamba-env-create.bash
+++ b/bin/sirius-script-mamba-env-create.bash
@@ -348,7 +348,8 @@ COMM="mamba install --freeze-installed -y"
 
 printf_yellow_clear "- System and generic python packages:\n"
 pip install build
-$COMM gxx make binutils swig=4.2.0 libxcrypt gsl libblas wmctrl fftw \
+# No not use freeze installed here, since it's the first time it is called.
+mamba install -y gxx make binutils swig=4.2.0 libxcrypt gsl libblas wmctrl fftw \
     pyparsing bottleneck aiohttp==3.7.4 numpy=1.23 scipy matplotlib \
     pytest mpmath entrypoints requests pyqt=5.12.3 pandas pyqtgraph=0.11.0 \
     qtpy=2.3.1 QtAwesome=0.7.2 numexpr tk sh pywavelets scikit-image \

--- a/bin/sirius-script-mamba-env-create.bash
+++ b/bin/sirius-script-mamba-env-create.bash
@@ -354,7 +354,7 @@ mamba install -y gxx make binutils swig=4.2.0 libxcrypt gsl libblas wmctrl fftw 
     pytest mpmath entrypoints requests pyqt=5.12.3 pandas pyqtgraph=0.11.0 \
     qtpy=2.3.1 QtAwesome=0.7.2 numexpr tk sh pywavelets scikit-image \
     scikit-learn pydocstyle pycodestyle pylama openpyxl gpy gpyopt fpdf sympy \
-    h5py scienceplots
+    h5py scienceplots seaborn
 
 printf_yellow_clear "- Install EPICS Base:\n"
 $COMM -c conda-forge/label/cf202003 epics-base=3.15.6

--- a/bin/sirius-script-mamba-env-create.bash
+++ b/bin/sirius-script-mamba-env-create.bash
@@ -592,3 +592,5 @@ EOM
 
 sudo chmod +x jupyter-mamba-${ENV_NAME} ipython-mamba-${ENV_NAME} designer-mamba-${ENV_NAME} \
     sirius-hla-as-ap-launcher-mamba-${ENV_NAME}
+
+printf_yellow "Finished!"

--- a/bin/sirius-script-mamba-env-create.bash
+++ b/bin/sirius-script-mamba-env-create.bash
@@ -347,7 +347,8 @@ printf_yellow "Install some mamba packages in $ENV_NAME environment.\n"
 COMM="mamba install --freeze-installed -y"
 
 printf_yellow_clear "- System and generic python packages:\n"
-$COMM gxx make binutils swig=4.2.0 libxcrypt build gsl libblas wmctrl fftw \
+pip install build
+$COMM gxx make binutils swig=4.2.0 libxcrypt gsl libblas wmctrl fftw \
     pyparsing bottleneck aiohttp==3.7.4 numpy=1.23 scipy matplotlib \
     pytest mpmath entrypoints requests pyqt=5.12.3 pandas pyqtgraph=0.11.0 \
     qtpy=2.3.1 QtAwesome=0.7.2 numexpr tk sh pywavelets scikit-image \

--- a/bin/sirius-script-mamba-env-create.bash
+++ b/bin/sirius-script-mamba-env-create.bash
@@ -492,7 +492,6 @@ defvar "PYQTDESIGNERPATH" "$CONDA_PREFIX/repos/hla/pyqt-apps"
 # Aliases
 # ======="
 alias g-conda="cd $CONDA_PREFIX"
-alias g-conda-repos="cd $CONDA_PREFIX/repos"
 EOM
 
 #### Cria arquivo para configurar desativação do ambiente
@@ -543,7 +542,6 @@ undefvar "PYQTDESIGNERPATH"
 # Aliases
 # =======
 unalias g-conda
-unalias g-conda-repos
 EOM
 
 ##############################################################################

--- a/bin/sirius-script-mamba-env-create.bash
+++ b/bin/sirius-script-mamba-env-create.bash
@@ -439,7 +439,7 @@ then
     clone_or_find fieldmaptrack lnls-fac && make $TARGET
     clone_or_find Radia lnls-sirius && make install 2>/dev/null
     clone_or_find idanalysis lnls-fac && make $TARGET
-    clone_or_find insertion-devices lnls-ima && make $TARGET
+    clone_or_find insertion-devices lnls-ids && make $TARGET
 fi
 
 printf_yellow_clear "Deactivate conda enviroment\n"

--- a/bin/sirius-script-mamba-env-create.bash
+++ b/bin/sirius-script-mamba-env-create.bash
@@ -559,25 +559,25 @@ printf_yellow "Create scripts to access apps in conda environment\n"
 
 cd /usr/local/bin
 printf_yellow_clear " - jupyter-mamba-${ENV_NAME} \n"
-sudo tee jupyter-mamba-${ENV_NAME} >/dev/null <<'EOM'
+sudo tee jupyter-mamba-${ENV_NAME} >/dev/null <<EOM
 #!/bin/bash
 bash -c "source /opt/mamba_files/mamba/etc/profile.d/conda.sh && conda activate ${ENV_NAME} && jupyter notebook"
 EOM
 
 printf_yellow_clear " - ipython-mamba-${ENV_NAME} \n"
-sudo tee ipython-mamba-${ENV_NAME} >/dev/null <<'EOM'
+sudo tee ipython-mamba-${ENV_NAME} >/dev/null <<EOM
 #!/bin/bash
 bash -c "source /opt/mamba_files/mamba/etc/profile.d/conda.sh && conda activate ${ENV_NAME} && ipython"
 EOM
 
 printf_yellow_clear " - designer-mamba-${ENV_NAME} \n"
-sudo tee designer-mamba-${ENV_NAME} >/dev/null <<'EOM'
+sudo tee designer-mamba-${ENV_NAME} >/dev/null <<EOM
 #!/bin/bash
 bash -c "source /opt/mamba_files/mamba/etc/profile.d/conda.sh && conda activate ${ENV_NAME} && designer"
 EOM
 
 printf_yellow_clear " - sirius-hla-as-ap-launcher-mamba-${ENV_NAME} \n"
-sudo tee sirius-hla-as-ap-launcher-mamba-${ENV_NAME} >/dev/null <<'EOM'
+sudo tee sirius-hla-as-ap-launcher-mamba-${ENV_NAME} >/dev/null <<EOM
 #!/bin/bash
 bash -c "source /opt/mamba_files/mamba/etc/profile.d/conda.sh && conda activate ${ENV_NAME} && sirius-hla-as-ap-launcher.py"
 EOM

--- a/bin/sirius-script-mamba-env-create.bash
+++ b/bin/sirius-script-mamba-env-create.bash
@@ -7,7 +7,7 @@ set -e
 # Parse arguments.
 # Adapted from: https://stackabuse.com/how-to-parse-command-line-arguments-in-bash/
 
-function help
+help()
 {
     echo "Usage: sirius-script-mamba-env-create.bash
     [ -c | --clone-repos ] Instead of finding repos in system, clone them inside environment folder.
@@ -115,22 +115,28 @@ done
 
 ##############################################################################
 # Define some useful functions
-function printf_yellow {
+printf_yellow()
+{
   printf "\e[1;33m$1\e[0m"
 }
-function printf_yellow_clear {
+printf_yellow_clear()
+{
   printf "\e[0;33m$1\e[0m"
 }
-function printf_blue {
+printf_blue()
+{
   printf "\e[1;34m$1\e[0m"
 }
-function printf_green {
+printf_green()
+{
   printf "\e[1;32m$1\e[0m"
 }
-function printf_red {
+printf_red()
+{
   printf "\e[1;31m$1\e[0m"
 }
-function _abort {
+_abort()
+{
   printf_red "SIGINT received. Aborting...\n"
   exit
 }
@@ -138,11 +144,11 @@ function _abort {
 # Trap SIG INT to abort exectution:
 trap _abort SIGINT;
 
-function get_branch
+get_branch()
 {
     for BRAN in "${BRANCHES[@]}"
     do
-        BR=(${BRAN//:/ })  # split string in array in delimiter ":"
+        local BR=(${BRAN//:/ })  # split string in array in delimiter ":"
         if [ "${BR[0]}" == "$1" ]
         then
             echo ${BR[1]}
@@ -169,7 +175,7 @@ extract_info_git()
 }
 
 # takes three input variables: repo name, organization, and repo tag/branch
-function clone_or_find
+clone_or_find()
 {
     printf_yellow " - $1\n"
     if [ "$CLONE" == "yes" ]
@@ -213,7 +219,7 @@ function clone_or_find
             return 1
         fi
     fi
-    BRAN="$(get_branch $1)"
+    local BRAN="$(get_branch $1)"
     if ! [ "$BRAN" ]
     then
         BRAN="$(get_branch all)"
@@ -446,7 +452,7 @@ printf_yellow "Add enviroment variables to conda environment\n"
 #### Create file to configure environment activation
 cat > $CONDA_PREFIX/etc/conda/activate.d/sirius_env.sh <<'EOM'
 # Define function to set variable and save previous state
-function defvar ()
+defvar()
 {
     tmp="${1}"
     if ! [ -z "${!tmp+x}" ]
@@ -493,7 +499,7 @@ EOM
 #### Cria arquivo para configurar desativação do ambiente
 cat > $CONDA_PREFIX/etc/conda/deactivate.d/sirius_env.sh <<'EOM'
 # Define function to unset variable with previous state
-function undefvar ()
+undefvar()
 {
     tmp="${1}"
     old="${tmp}_OLD"

--- a/bin/sirius-script-mamba-env-create.bash
+++ b/bin/sirius-script-mamba-env-create.bash
@@ -450,12 +450,13 @@ then
 fi
 
 printf_yellow_clear "Deactivate conda enviroment\n"
+CONDA_PREF=$CONDA_PREFIX
 mamba deactivate
 
 printf_yellow "Add enviroment variables to conda environment\n"
 
 #### Create file to configure environment activation
-cat > $CONDA_PREFIX/etc/conda/activate.d/sirius_env.sh <<'EOM'
+cat > $CONDA_PREF/etc/conda/activate.d/sirius_env.sh <<'EOM'
 # Define function to set variable and save previous state
 defvar()
 {
@@ -502,7 +503,7 @@ alias g-conda="cd $CONDA_PREFIX"
 EOM
 
 #### Cria arquivo para configurar desativação do ambiente
-cat > $CONDA_PREFIX/etc/conda/deactivate.d/sirius_env.sh <<'EOM'
+cat > $CONDA_PREF/etc/conda/deactivate.d/sirius_env.sh <<'EOM'
 # Define function to unset variable with previous state
 undefvar()
 {
@@ -550,6 +551,8 @@ undefvar "PYQTDESIGNERPATH"
 # =======
 unalias g-conda
 EOM
+
+unset CONDA_PREF
 
 ##############################################################################
 printf_yellow "Fix permissions of some files\n"

--- a/bin/sirius-script-mamba-env-create.bash
+++ b/bin/sirius-script-mamba-env-create.bash
@@ -53,7 +53,7 @@ INST_IOC="yes"
 INST_IMA="yes"
 INST_COL="yes"
 ROOT_REP="/"
-BRANCHES="Radia:lnls-sirius"
+BRANCHES=""
 ENV_NAME="sirius"
 # now enjoy the options in order and nicely split until we see --
 while true; do

--- a/bin/sirius-script-mamba-env-create.bash
+++ b/bin/sirius-script-mamba-env-create.bash
@@ -151,6 +151,23 @@ function get_branch
     done
 }
 
+# This function extracts the organization and repo name from a
+# remote.origin.url of a given repository.
+# It was done by Microsoft Windows Copilot and works for urls such as:
+#    - git@github.com:org/repo.git
+#    - https://gitlab.com/org/repo.git
+#    - git@bitbucket.org:org/repo.git
+#    - lnls-sirius/scripts.git
+extract_info_git()
+{
+    local url="$1"
+    local path=$(echo "$url" | sed -E 's|.*[:/]([^/]+/[^/]+)$|\1|')
+    path=${path%.git}
+    local org=$(echo "$path" | cut -d'/' -f1)
+    local repo=$(echo "$path" | cut -d'/' -f2)
+    echo "$org" "$repo"
+}
+
 # takes three input variables: repo name, organization, and repo tag/branch
 function clone_or_find
 {
@@ -177,11 +194,11 @@ function clone_or_find
             cd $V
             if git rev-parse --is-inside-work-tree 1>/dev/null 2>&1
             then
-                PH=`git rev-parse --show-toplevel`
-                NAME="$(basename $PH)"
-                if [ "$NAME" == "$1" ]
+                local NAME=$(git config --get remote.origin.url)
+                NAME=$(extract_info_git "$NAME")
+                if [ "$NAME" == "$2 $1" ]
                 then
-                    PTH="$PH"
+                    PTH=$(git rev-parse --show-toplevel)
                     break
                 fi
             fi

--- a/bin/sirius-script-mamba-env-create.bash
+++ b/bin/sirius-script-mamba-env-create.bash
@@ -11,6 +11,7 @@ help()
 {
     echo "Usage: sirius-script-mamba-env-create.bash
     [ -c | --clone-repos ] Instead of finding repos in system, clone them inside environment folder.
+    [ -f | --clone-folder ] If repos will be cloned, clone them in this folder. Default: ~/repos.
     [ -d | --develop ] Install sirius packages in develop mode.
     [ --no-sim ] Do not install simulation packages.
     [ --no-ioc ] Do not install IOC related packages.
@@ -31,8 +32,8 @@ help()
     [ -h | --help  ] Print help and exit."
 }
 
-SHORT="cdr:b:e:h"
-LONG+="clone-repos,develop,no-sim,no-ioc,no-ima,no-colleff,"
+SHORT="cf:dr:b:e:h"
+LONG+="clone-repos,clone-folder:,develop,no-sim,no-ioc,no-ima,no-colleff,"
 LONG+="root-lnls-repos:,branches:,env-name:,help"
 OPTS=$(getopt -a -n sirius-script-mamba-env-create.bash \
     --options $SHORT --longoptions $LONG -- "$@")
@@ -47,6 +48,7 @@ fi
 eval set -- "$OPTS"
 
 CLONE="no"
+CLONE_FOL="~/repos"
 DEVELOP="no"
 INST_SIM="yes"
 INST_IOC="yes"
@@ -61,6 +63,10 @@ while true; do
         -c|--clone-repos)
             CLONE="yes"
             shift
+            ;;
+        -f|--clone-folder)
+            CLONE_FOL="$2"
+            shift 2
             ;;
         -d|--develop)
             DEVELOP="yes"
@@ -180,8 +186,8 @@ clone_or_find()
     printf_yellow " - $1\n"
     if [ "$CLONE" == "yes" ]
     then
-        printf_yellow_clear "Cloning repo $1 in $CONDA_PREFIX/repos: \n"
-        cd $CONDA_PREFIX/repos
+        printf_yellow_clear "Cloning repo $1 in $CLONE_FOL: \n"
+        cd $CLONE_FOL
         if ! [ -d "$1" ]
         then
             git clone https://github.com/$2/$1.git
@@ -382,10 +388,10 @@ mamba update jupyter_client
 if [ "$CLONE" == "yes" ]
 then
     printf_yellow "Clone and install our applications.\n"
-    printf_yellow_clear "Creating folder $CONDA_PREFIX/repos: "
-    if ! [ -d $CONDA_PREFIX/repos ]
+    printf_yellow_clear "Creating folder $CLONE_FOL: "
+    if ! [ -d $CLONE_FOL ]
     then
-        mkdir $CONDA_PREFIX/repos
+        mkdir $CLONE_FOL
         printf_green "done!\n"
     else
         printf_blue "already exists. Skipping...\n"

--- a/bin/sirius-script-mamba-env-create.bash
+++ b/bin/sirius-script-mamba-env-create.bash
@@ -16,9 +16,7 @@ function help
     [ --no-ioc ] Do not install IOC related packages.
     [ --no-ima ] Do not install magnets simulation packages.
     [ --no-colleff ] Do not install collective effects packages.
-    [ --root-lnls-fac ] Root folder for lnls-fac repos. Default: \"/\".
-    [ --root-lnls-sirius ] Root folder for lnls-sirius repos. Default: \"/\".
-    [ --root-lnls-ima ] Root folder for lnls-imas repos. Default: \"/\".
+    [ -r | --root-lnls-repos ] Root folder for lnls repos. Default: \"/\".
     [ -b | --branches ] Branches to install. For each package you want to force a branch you must provide:
             <package1>:<branch1>,<package2>:<branch2>,...,<packagen>:<branchn>
         Please note there is no spaces in the string.
@@ -33,9 +31,9 @@ function help
     [ -h | --help  ] Print help and exit."
 }
 
-SHORT="cdb:e:h"
-LONG+="clone-repos,develop,no-sim,no-ioc,no-ima,no-colleff,root-lnls-fac:,"
-LONG+="root-lnls-sirius:,root-lnls-ima:,branches:,env-name:,help"
+SHORT="cdr:b:e:h"
+LONG+="clone-repos,develop,no-sim,no-ioc,no-ima,no-colleff,"
+LONG+="root-lnls-repos:,branches:,env-name:,help"
 OPTS=$(getopt -a -n sirius-script-mamba-env-create.bash \
     --options $SHORT --longoptions $LONG -- "$@")
 
@@ -54,9 +52,7 @@ INST_SIM="yes"
 INST_IOC="yes"
 INST_IMA="yes"
 INST_COL="yes"
-ROOT_SIR="/"
-ROOT_FAC="/"
-ROOT_IMA="/"
+ROOT_REP="/"
 BRANCHES="Radia:lnls-sirius"
 ENV_NAME="sirius"
 # now enjoy the options in order and nicely split until we see --
@@ -86,16 +82,8 @@ while true; do
             INST_COL="no"
             shift
             ;;
-        --root-lnls-fac)
-            ROOT_FAC="$2"
-            shift 2
-            ;;
-        --root-lnls-sirius)
-            ROOT_SIR="$2"
-            shift 2
-            ;;
-        --root-lnls-ima)
-            ROOT_IMA="$2"
+        -r|--root-lnls-repos)
+            ROOT_REP="$2"
             shift 2
             ;;
         -b|--branches)
@@ -180,19 +168,10 @@ function clone_or_find
         fi
         cd $1
     else
-        ROO=$ROOT_SIR
-        if [ $2 == "lnls-fac" ]
-        then
-            ROO=$ROOT_FAC
-        elif [ $2 == "lnls-ima" ]
-        then
-            ROO=$ROOT_IMA
-        fi
-
-        printf_yellow_clear "Searching repo $1 in $ROO: "
-        VAR="$(find $ROO -path */$1 2>/dev/null)"
+        printf_yellow_clear "Searching repo $1 in $ROOT_REP: "
+        local PTH=
+        local VAR="$(find "$ROOT_REP" -path */$1 2>/dev/null)"
         VAR=($VAR)
-        PTH=
         for V in "${VAR[@]}"
         do
             cd $V


### PR DESCRIPTION
since last year, several changes took place with the Mambaforge project. Now the installer is called Miniforge3 and the initialization method of mamba changed.

Besides, I wasn't able to install the build package with mamba anymore, so I changed the script to install it with pip.

This PR will come together with several other PRs in basically all of our repositories, because since the beggining of this year, pip deprecated the explicit use of the setup.py file as a command line tool, as can be seen in this [link](https://packaging.python.org/en/latest/discussions/setup-py-deprecated/#setup-py-deprecated) and on this github [issue](https://github.com/pypa/pip/issues/11457).

Now it is highly reccomended to have a pyproject.toml file inside the repositories with a [build-system] table, as discussed [here](https://packaging.python.org/en/latest/guides/modernize-setup-py-project/#modernize-setup-py-project).

Actually, now it is possible to completely remove the setup.py file, since all metadata configurations are supported by the pyproject.toml file, as shown [here](https://packaging.python.org/en/latest/specifications/pyproject-toml/#pyproject-project-table) and [here](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/). This [link](https://toml.io/en/v1.0.0#table) also brings a complete specification of the .toml syntax, which can be helpful to understand the definitions on the PRs I'll link with this one.

Additionally, this [link](https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html) helps us defining all specific setuptools metadata configurations within the pyproject.toml file, making the setup.py completely unnecessary. You guys will notice in my PRs, however, that I kept the file setup.py for now, with duplicated informations. This is because we still need to support python3.6, which still has older versions of pip and setuptools, that does not fully support this new installation mechanism. As soon as the PCs from the control room have their OS updated and we abandon python3.6, I'll make PRs removing the setup.py files from all our repositories.

List of PRs linked with this one.
lnls-fac:
 - lnls-fac/mathphys#37
 - lnls-fac/lnls#16
 - lnls-fac/trackcpp#84
 - lnls-fac/pyaccel#157
 - lnls-fac/pymodels#113
 - lnls-fac/apsuite#298
 - lnls-fac/hlafac#33
 - lnls-fac/collective_effects#34
 - lnls-fac/fieldmaptrack#18
 - lnls-fac/idanalysis#14

lnls-sirius:
 - lnls-sirius/dev-packages#1171
 - lnls-sirius/hla#747
 - lnls-sirius/machine-applications#319
 - lnls-sirius/Radia#2

lnls-ima:
 - lnls-ima/insertion-devices#61
 
lnls-ids:
 - lnls-ids/insertion-devices#2

 Guys, @anacso17, I finished making all pull requests related to this PR. It would be nice if we could test a deploy on the control room with these branches. Do you think it is possible to do this?
 
 I just tested the mamba installation script using the new branches for all repositories and it worked well.
@afonsoln also tested the micromamba installation file (.yml) for the hla using the new branches and it also worked.